### PR TITLE
Reset the default CRAN repo

### DIFF
--- a/rstudio-hpc.def
+++ b/rstudio-hpc.def
@@ -78,6 +78,9 @@ From: rocker/tidyverse:3.6.3
     add_host_command /opt/pbs/bin/qsub qsub
     add_host_command /opt/pbs/bin/qterm qterm
     add_host_command /opt/pbs/bin/tracejob tracejob
+    
+    # Reset the default CRAN repo so that user installed packages don't use a CRAN snapshot from built time
+    echo "options(repos = c(CRAN = 'https://cran.rstudio.org'))" >> /usr/local/lib/R/etc/Rprofile.site
 
 %environment
     # add env vars


### PR DESCRIPTION
This is a fix for the bug identified in #4. The CRAN repo is set to a snapshot so that when a user tries to install new packages they get old versions. Adding the .rprofile makes sure the repo is research *after* build time installed packages. 